### PR TITLE
Adaption so that tags are also suggested during adding a new task

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,39 @@
 **myTDX** (my tiny todo extended)
 
+** Use following nginx config file **
+```
+server {
+        listen 4001 default_server;
+
+        root /srv/http/myTDX;
+        server_name _;
+        autoindex off;
+
+        proxy_intercept_errors on;
+        index myTDX/index.php index.php index.html index.htm;
+
+# deny access to hidden files and for instance Git directories
+	location ~ /\.(?!well-known).* {
+	    deny all;
+	        access_log off;
+		    log_not_found off;
+}
+
+
+        location ~ \.php$ {
+                include fastcgi.conf;
+                fastcgi_intercept_errors on;
+                fastcgi_pass  127.0.0.1:9000;
+                fastcgi_param SERVER_NAME \$host;
+        }
+
+        location ~ /\.ht {
+                deny all;
+        }
+}
+```
+
+
 As the name suggests, this project is heavily based on an old but very well done ajax todolist
 written by maxpozdeev/mytinytodo (http://www.mytinytodo.net/). It also works quite well on mobile phones.
 The older project was resumed years after being frozen, and now the two variants have diverged significantly.

--- a/ajax.php
+++ b/ajax.php
@@ -360,9 +360,8 @@ elseif(isset($_GET['suggestTags']))
 	$begin = trim(_get('q'));
 	$limit = (int)_get('limit');
 	if($limit<1) $limit = 8;
-	#$q = $db->dq("SELECT name,id FROM {$db->prefix}tags INNER JOIN {$db->prefix}tag2task ON id=tag_id WHERE list_id=$listId AND name LIKE ".
 	$q = $db->dq("SELECT name,id FROM {$db->prefix}tags INNER JOIN {$db->prefix}tag2task ON id=tag_id WHERE name LIKE ".
-					$db->quoteForLike('%s%%',$begin) ." GROUP BY tag_id ORDER BY name LIMIT $limit");
+					$db->quoteForLike('%s%%',$begin) ." GROUP BY tag_id ORDER BY name LIMIT $limit"); 
 	$s = '';
 	while($r = $q->fetch_row()) {
 		$s .= "$r[0]|$r[1]\n";

--- a/ajax.php
+++ b/ajax.php
@@ -361,7 +361,8 @@ elseif(isset($_GET['suggestTags']))
 	$begin = trim(_get('q'));
 	$limit = (int)_get('limit');
 	if($limit<1) $limit = 8;
-	$q = $db->dq("SELECT name,id FROM {$db->prefix}tags INNER JOIN {$db->prefix}tag2task ON id=tag_id WHERE list_id=$listId AND name LIKE ".
+	#$q = $db->dq("SELECT name,id FROM {$db->prefix}tags INNER JOIN {$db->prefix}tag2task ON id=tag_id WHERE list_id=$listId AND name LIKE ".
+	$q = $db->dq("SELECT name,id FROM {$db->prefix}tags INNER JOIN {$db->prefix}tag2task ON id=tag_id WHERE name LIKE ".
 					$db->quoteForLike('%s%%',$begin) ." GROUP BY tag_id ORDER BY name LIMIT $limit");
 	$s = '';
 	while($r = $q->fetch_row()) {

--- a/init.php
+++ b/init.php
@@ -51,6 +51,10 @@ require_once(MTTPATH. 'lang/'.Config::get('lang').'.php');
 $_mttinfo = array();
 
 $needAuth = (Config::get('password') != '') ? 1 : 0;
+# baswi added next line, because after configuring password I could not get in
+# $needAuth = 0;
+
+
 if($needAuth && !isset($dontStartSession))
 {
 	if(Config::get('session') == 'files')

--- a/mytinytodo.js
+++ b/mytinytodo.js
@@ -21,7 +21,7 @@ var tabLists = {
 	_alltasks: {},
 	clear: function(){
 		this._lists = {}; this._length = 0; this._order = [];
-		this._alltasks = { id:-1, showCompl:0, sort:3 }; 
+		this._alltasks = { id:-1, showCompl:0, sort:2 }; 
 	},
 	length: function(){ return this._length; },
 	exists: function(id){ if(this._lists[id] || id==-1) return true; else return false; },

--- a/mytinytodo.js
+++ b/mytinytodo.js
@@ -318,7 +318,16 @@ var mytinytodo = window.mytinytodo = _mtt = {
 			dayNamesMin:_mtt.lang.daysMin, dayNames:_mtt.lang.daysLong, monthNamesShort:_mtt.lang.monthsLong
 		});
 
-		$("#edittags").autocomplete('ajax.php?suggestTags', {scroll: false, multiple: true, selectFirst:false, max:8, extraParams:{list:function(){ var taskId = document.getElementById('taskedit_form').id.value; return taskList[taskId].listId; }}});
+		$("#edittags").autocomplete('ajax.php?suggestTags', {scroll: false, multiple: true, selectFirst:false, max:8, extraParams:{list:function(){ var taskId = document.getElementById('taskedit_form').id.value; 
+		if (taskId)
+	              return taskList[taskId].listId;
+		else
+		      return -1; //will be the case during adding a new task
+		}}});
+
+
+
+
 
 		$('#taskedit_form').find('select,input,textarea').bind('change keypress', function(){
 			flag.editFormChanged = true;


### PR DESCRIPTION
I rely havely on suggested tags, also during adding new tasks. Of course to prevent accidentally typing a wrong tag.
This was working in your version, so I made a few modifications.
Could you review these changes?